### PR TITLE
Remove CSRF_TRUSTED_ORIGINS_WITH_SCHEMES variable

### DIFF
--- a/registrar/settings/base.py
+++ b/registrar/settings/base.py
@@ -327,7 +327,6 @@ SERVICE_USER = 'registrar_service_user'
 SESSION_EXPIRE_AT_BROWSER_CLOSE = False
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
 CSRF_TRUSTED_ORIGINS = []
-CSRF_TRUSTED_ORIGINS_WITH_SCHEMES = []  # temporary setting for Django 4.2 support
 CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',

--- a/registrar/settings/production.py
+++ b/registrar/settings/production.py
@@ -1,5 +1,4 @@
 from os import environ
-import django
 import yaml
 
 from registrar.settings.base import *
@@ -54,6 +53,3 @@ CELERY_BROKER_URL = "{}://{}:{}@{}/{}".format(
     CELERY_BROKER_HOSTNAME,
     CELERY_BROKER_VHOST
 )
-
-if django.VERSION[0] >= 4:  # for greater than django 3.2 use schemes.
-    CSRF_TRUSTED_ORIGINS = CSRF_TRUSTED_ORIGINS_WITH_SCHEMES


### PR DESCRIPTION
## Description

- PR created under the issue https://github.com/edx/edx-arch-experiments/issues/460
- Since we have upgraded to Django 4.2, we can remove the additional condition and variable.
