### PR TITLE
feat: Add bulk fetching and caching for program details from Discovery service

### DIFF
--- a/registrar/apps/core/api_client.py
+++ b/registrar/apps/core/api_client.py
@@ -44,7 +44,8 @@ class DiscoveryServiceClient:
     @classmethod
     def get_programs_by_types(cls, types):
         """
-        Fetch a JSON representation of all active programs of specified types from the Discovery service.
+        Fetch a JSON representation of all active programs of specified
+        types from the Discovery service.
 
         Returns empty if not found or other HTTP error.
 
@@ -62,15 +63,48 @@ class DiscoveryServiceClient:
             return get_all_paginated_results(url)
         except HTTPError:
             logger.exception(
-                "Failed to load programs with program_types %s from Discovery service.",
+                "Failed to load programs with program_types %s from "
+                "Discovery service.",
                 ','.join(types),
+            )
+            return []
+
+    @classmethod
+    def get_programs_by_uuids(cls, uuids):
+        """
+        Fetch a JSON representation of programs by their UUIDs from the
+        Discovery service.
+
+        Returns empty if not found or other HTTP error.
+
+        Arguments:
+            * uuids: [program_uuids]
+
+        Returns: [programs] | []
+        """
+        if not uuids:
+            return []
+
+        url = urljoin(
+            settings.DISCOVERY_BASE_URL,
+            DISCOVERY_API_TPL.format('programs', '')
+        )
+        url += f'?uuids={",".join(str(uuid) for uuid in uuids)}'
+        try:
+            return get_all_paginated_results(url)
+        except HTTPError:
+            logger.exception(
+                "Failed to load programs with uuids %s from "
+                "Discovery service.",
+                ','.join(str(uuid) for uuid in uuids),
             )
             return []
 
     @classmethod
     def get_organizations(cls):
         """
-        Fetch a JSON representation of organizations from the Discovery service.
+        Fetch a JSON representation of organizations from the Discovery
+        service.
 
         Returns None if not found or other HTTP error.
 

--- a/registrar/apps/core/discovery_cache.py
+++ b/registrar/apps/core/discovery_cache.py
@@ -39,6 +39,17 @@ class ProgramDetails:
             # ...
     """
 
+    @classmethod
+    def _get_default_chunk_size(cls):
+        """
+        Get the default chunk size from environment settings.
+
+        Returns:
+            int: The chunk size from REGISTRAR_DISCOVERY_PROGRAMS_API_BATCH_SIZE setting,
+                 or 20 if not configured.
+        """
+        return getattr(settings, 'REGISTRAR_DISCOVERY_PROGRAMS_API_BATCH_SIZE', 20)
+
     def __init__(self, uuid):
         """
         Initialize a program details instance and load details from cache or Discovery.
@@ -76,6 +87,103 @@ class ProgramDetails:
         return data
 
     @classmethod
+    def _get_raw_data_for_programs(cls, uuids, chunk_size=None):
+        """
+        Retrieve JSON data for multiple programs, using bulk fetching and caching.
+
+        This method efficiently fetches multiple programs by:
+        1. Checking cache for existing programs
+        2. Bulk fetching missing programs from Discovery API
+        3. Caching all fetched results
+
+        Arguments:
+            uuids (Iterable[UUID|str]): UUIDs of programs to fetch
+            chunk_size (int): Maximum UUIDs per API request
+                (default: from settings.REGISTRAR_DISCOVERY_PROGRAMS_API_BATCH_SIZE)
+
+        Returns: dict[str, dict] - Mapping of UUID strings to program data
+        """
+        if not uuids:
+            return {}
+
+        # Convert all UUIDs to strings for consistency
+        str_uuids = [str(uuid) for uuid in uuids]
+        programs_dict = {}
+        uuids_to_fetch = []
+
+        # Check cache for existing programs
+        cache_keys = [PROGRAM_CACHE_KEY_TPL.format(uuid=uuid) for uuid in str_uuids]
+        cached_programs = cache.get_many(cache_keys)
+
+        for uuid_str in str_uuids:
+            cache_key = PROGRAM_CACHE_KEY_TPL.format(uuid=uuid_str)
+            if cache_key in cached_programs and isinstance(cached_programs[cache_key], dict):
+                programs_dict[uuid_str] = cached_programs[cache_key]
+            else:
+                uuids_to_fetch.append(uuid_str)
+
+        # Fetch missing programs from API in chunks
+        if uuids_to_fetch:
+            fetched_programs = cls._fetch_programs_bulk(uuids_to_fetch, chunk_size)
+
+            # Process fetched programs and prepare for caching
+            cache_data = {}
+            found_uuids = set()
+
+            for program in fetched_programs:
+                program_uuid = str(program.get('uuid'))
+                if program_uuid:
+                    programs_dict[program_uuid] = program
+                    cache_key = PROGRAM_CACHE_KEY_TPL.format(uuid=program_uuid)
+                    cache_data[cache_key] = program
+                    found_uuids.add(program_uuid)
+
+            # Cache fetched programs
+            if cache_data:
+                cache.set_many(cache_data, settings.PROGRAM_CACHE_TIMEOUT)
+
+            # Missing UUIDs that weren't found in Discovery Programs
+            missing_uuids = set(uuids_to_fetch) - found_uuids
+            if missing_uuids:
+                # Add empty dicts to result for missing programs
+                for uuid in missing_uuids:
+                    programs_dict[uuid] = {}
+
+        return programs_dict
+
+    @classmethod
+    def _fetch_programs_bulk(cls, uuids, chunk_size=None):
+        """
+        Fetch raw program data for multiple UUIDs from Discovery API in batches.
+
+        Arguments:
+            uuids (Iterable[UUID|str]): UUIDs of programs to fetch
+            chunk_size (int, optional): Maximum UUIDs per API request.
+                                      If None, uses environment setting.
+
+        Returns: list[dict] - List of program data dictionaries
+        """
+        if chunk_size is None:
+            chunk_size = cls._get_default_chunk_size()
+        all_programs = []
+        # Process UUIDs in chunks to stay within URL length limits
+        for i in range(0, len(uuids), chunk_size):
+            chunk_uuids = uuids[i:i + chunk_size]
+
+            try:
+                chunk_programs = DiscoveryServiceClient.get_programs_by_uuids(chunk_uuids)
+                if isinstance(chunk_programs, list):
+                    all_programs.extend(chunk_programs)
+            except Exception:
+                logger.exception(
+                    "Failed to load programs chunk with uuids %s from Discovery service.",
+                    ','.join(chunk_uuids),
+                )
+                continue
+
+        return all_programs
+
+    @classmethod
     def clear_cache_for_programs(cls, program_uuids):
         """
         Clear any details from Discovery that we have cached for the given programs.
@@ -90,23 +198,57 @@ class ProgramDetails:
         cache.delete_many(cache_keys_to_delete)
 
     @classmethod
-    def load_many(cls, uuids):
+    def load_many(cls, uuids, chunk_size=None):
         """
-        Given program UUIDs, load a dict of ProgramDetail instances, keyed by UUID.
-
-        TODO MST-266:
-        This is currently no more efficient than loading the details one-by-one.
-        For programs that aren't in the cache, we ought to load them in a single
-        API call to Course Disocovery.
+        Load multiple ProgramDetails objects for the given program UUIDs.
 
         Arguments:
-            uuids (Iterable[str|UUID]): Program UUIDs.
+            uuids (Iterable[UUID|str]): UUIDs of programs to load
+            chunk_size (int): Maximum UUIDs per API request
+                (default: from settings.REGISTRAR_DISCOVERY_PROGRAMS_API_BATCH_SIZE)
 
-        Returns: dict[(str|UUID): Program]
+        Returns: dict[UUID, ProgramDetails] - Mapping of UUIDs to ProgramDetails objects
         """
-        return {
-            uuid: ProgramDetails(uuid) for uuid in uuids
-        }
+        if not uuids:
+            return {}
+
+        # Convert UUIDs to consistent string format for processing
+        uuid_list = [str(uuid) for uuid in uuids]
+
+        # Get chunk size from environment if not provided
+        if chunk_size is None:
+            chunk_size = cls._get_default_chunk_size()
+
+        # Bulk fetch raw data for all programs
+        programs_raw_data = cls._get_raw_data_for_programs(uuid_list, chunk_size)
+
+        # Create ProgramDetails instances using the bulk-fetched data
+        result = {}
+        for original_uuid in uuids:
+            str_uuid = str(original_uuid)
+            # Create instance with pre-fetched data to avoid individual API calls
+            program_details = cls._create_with_raw_data(original_uuid, programs_raw_data.get(str_uuid, {}))
+            result[original_uuid] = program_details
+
+        return result
+
+    @classmethod
+    def _create_with_raw_data(cls, uuid, raw_data):
+        """
+        Create a ProgramDetails instance with pre-fetched raw data.
+
+        This bypasses the normal constructor's API call since we already have the data.
+
+        Arguments:
+            uuid (UUID|str): UUID of the program
+            raw_data (dict): Pre-fetched program data from Discovery API
+
+        Returns: ProgramDetails
+        """
+        instance = cls.__new__(cls)  # Create instance without calling __init__
+        instance.uuid = uuid
+        instance.raw_data = raw_data if isinstance(raw_data, dict) else {}
+        return instance
 
     @property
     def title(self):

--- a/registrar/apps/core/tests/test_discovery_cache.py
+++ b/registrar/apps/core/tests/test_discovery_cache.py
@@ -4,13 +4,13 @@ Tests for core proxy models.
 
 from posixpath import join as urljoin
 from unittest.mock import patch
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import ddt
 import responses
 from django.conf import settings
 from django.core.cache import cache
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from ..api_client import DISCOVERY_API_TPL, DiscoveryServiceClient
 from ..discovery_cache import ProgramDetails
@@ -62,8 +62,12 @@ class ProgramDetailsTestCase(TestCase):
     )
 
     inactive_curriculum_uuid = UUID("77777777-4444-2222-1111-000000000000")
-    active_curriculum_uuid = UUID("77777777-4444-2222-1111-000000000001")
-    ignored_active_curriculum_uuid = UUID("77777777-4444-2222-1111-000000000002")
+    active_curriculum_uuid = UUID(
+        "77777777-4444-2222-1111-000000000001"
+    )
+    ignored_active_curriculum_uuid = UUID(
+        "77777777-4444-2222-1111-000000000002"
+    )
 
     program_from_discovery = {
         'title': "Master's in CS",
@@ -74,17 +78,29 @@ class ProgramDetailsTestCase(TestCase):
                 # Inactive curriculum. Should be ignored.
                 'uuid': str(inactive_curriculum_uuid),
                 'is_active': False,
-                'courses': [{'course_runs': [make_course_run(0, True)]}],
+                'courses': [
+                    {'course_runs': [make_course_run(0, True)]}
+                ],
             },
             {
-                # Active curriculum. All three course runs should be aggregated.
+                # Active curriculum. All three course runs should be
+                # aggregated.
                 'uuid': str(active_curriculum_uuid),
                 'is_active': True,
                 'courses': [
                     {'course_runs': [make_course_run(1)]},
                     {'course_runs': []},
-                    {'course_runs': [make_course_run(2, True), make_course_run(3)]},
-                    {'course_runs': [{'this course run': 'has the wrong format'}]},
+                    {
+                        'course_runs': [
+                            make_course_run(2, True),
+                            make_course_run(3)
+                        ]
+                    },
+                    {
+                        'course_runs': [
+                            {'this course run': 'has the wrong format'}
+                        ]
+                    },
                 ]
             },
             {
@@ -92,7 +108,9 @@ class ProgramDetailsTestCase(TestCase):
                 # In current implementation, should be ignored.
                 'uuid': str(ignored_active_curriculum_uuid),
                 'is_active': True,
-                'courses': [{'course_runs': [make_course_run(4, True)]}],
+                'courses': [
+                    {'course_runs': [make_course_run(4, True)]}
+                ],
             },
         ],
     }
@@ -111,7 +129,9 @@ class ProgramDetailsTestCase(TestCase):
         (500, {'message': 'everything is broken'}, {}),
     )
     @ddt.unpack
-    def test_discovery_program_get(self, disco_status, disco_json, expected_raw_data):
+    def test_discovery_program_get(
+        self, disco_status, disco_json, expected_raw_data
+    ):
         responses.add(
             responses.GET,
             self.discovery_url,
@@ -155,14 +175,392 @@ class ProgramDetailsTestCase(TestCase):
         # Real course run, in active curriculum, only has internal course key.
         ('course-v1:TestRun+1', 'course-v1:TestRun+1', None),
         ('testorg-course-1', None, None),
-        # Real course run, in active curriculum, has internal and external keys.
-        ('course-v1:TestRun+2', 'course-v1:TestRun+2', 'testorg-course-2'),
-        ('testorg-course-2', 'course-v1:TestRun+2', 'testorg-course-2'),
+        # Real course run, in active curriculum, has internal and
+        # external keys.
+        (
+            'course-v1:TestRun+2',
+            'course-v1:TestRun+2',
+            'testorg-course-2'
+        ),
+        (
+            'testorg-course-2',
+            'course-v1:TestRun+2',
+            'testorg-course-2'
+        ),
     )
     @ddt.unpack
-    def test_get_course_keys(self, argument, expected_course_key, expected_external_key):
+    def test_get_course_keys(
+        self, argument, expected_course_key, expected_external_key
+    ):
         program = ProgramDetails(self.program_uuid)
         actual_course_key = program.get_course_key(argument)
         assert actual_course_key == expected_course_key
         actual_external_key = program.get_external_course_key(argument)
         assert actual_external_key == expected_external_key
+
+
+class ProgramDetailsBulkFetchingTestCase(TestCase):
+    """
+    Test ProgramDetails bulk fetching functionality.
+    """
+    # pylint: disable=protected-access  # Testing private methods
+    program_uuid_1 = UUID("11111111-1111-1111-1111-111111111111")
+    program_uuid_2 = UUID("22222222-2222-2222-2222-222222222222")
+    program_uuid_3 = UUID("33333333-3333-3333-3333-333333333333")
+
+    program_1_data = {
+        'uuid': str(program_uuid_1),
+        'title': "Test Program 1",
+        'type': "Masters",
+        'marketing_url': "https://example.com/program1",
+    }
+
+    program_2_data = {
+        'uuid': str(program_uuid_2),
+        'title': "Test Program 2",
+        'type': "MicroMasters",
+        'marketing_url': "https://example.com/program2",
+    }
+
+    program_3_data = {
+        'uuid': str(program_uuid_3),
+        'title': "Test Program 3",
+        'type': "Masters",
+        'marketing_url': "https://example.com/program3",
+    }
+
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+
+    def test_get_raw_data_for_programs_empty_list(self):
+        """Test that empty list returns empty dict."""
+        result = ProgramDetails._get_raw_data_for_programs([])
+        self.assertEqual(result, {})
+
+    @patch.object(DiscoveryServiceClient, 'get_programs_by_uuids')
+    def test_get_raw_data_for_programs_all_cached(self, mock_get_programs):
+        """Test that cached programs don't trigger API calls."""
+        # Pre-populate cache
+        cache.set(
+            f'program:{self.program_uuid_1}', self.program_1_data, 300
+        )
+        cache.set(
+            f'program:{self.program_uuid_2}', self.program_2_data, 300
+        )
+
+        uuids = [self.program_uuid_1, self.program_uuid_2]
+        result = ProgramDetails._get_raw_data_for_programs(uuids)
+
+        # Should not call API
+        mock_get_programs.assert_not_called()
+
+        # Should return cached data
+        expected = {
+            str(self.program_uuid_1): self.program_1_data,
+            str(self.program_uuid_2): self.program_2_data,
+        }
+        self.assertEqual(result, expected)
+
+    @patch.object(DiscoveryServiceClient, 'get_programs_by_uuids')
+    def test_get_raw_data_for_programs_none_cached(self, mock_get_programs):
+        """Test that uncached programs trigger API calls and get cached."""
+        mock_get_programs.return_value = [
+            self.program_1_data, self.program_2_data
+        ]
+
+        uuids = [self.program_uuid_1, self.program_uuid_2]
+        result = ProgramDetails._get_raw_data_for_programs(uuids)
+
+        # Should call API once
+        mock_get_programs.assert_called_once_with([
+            str(self.program_uuid_1), str(self.program_uuid_2)
+        ])
+
+        # Should return API data
+        expected = {
+            str(self.program_uuid_1): self.program_1_data,
+            str(self.program_uuid_2): self.program_2_data,
+        }
+        self.assertEqual(result, expected)
+
+        # Data should be cached
+        self.assertEqual(
+            cache.get(f'program:{self.program_uuid_1}'), self.program_1_data
+        )
+        self.assertEqual(
+            cache.get(f'program:{self.program_uuid_2}'), self.program_2_data
+        )
+
+    @patch.object(DiscoveryServiceClient, 'get_programs_by_uuids')
+    def test_get_raw_data_for_programs_mixed_cache(self, mock_get_programs):
+        """Test that mix of cached and uncached programs works correctly."""
+        # Pre-populate cache with one program
+        cache.set(
+            f'program:{self.program_uuid_1}', self.program_1_data, 300
+        )
+
+        # Mock API to return only the uncached program
+        mock_get_programs.return_value = [self.program_2_data]
+
+        uuids = [self.program_uuid_1, self.program_uuid_2]
+        result = ProgramDetails._get_raw_data_for_programs(uuids)
+
+        # Should call API only for uncached program
+        mock_get_programs.assert_called_once_with([
+            str(self.program_uuid_2)
+        ])
+
+        # Should return both cached and API data
+        expected = {
+            str(self.program_uuid_1): self.program_1_data,
+            str(self.program_uuid_2): self.program_2_data,
+        }
+        self.assertEqual(result, expected)
+
+    @patch.object(DiscoveryServiceClient, 'get_programs_by_uuids')
+    def test_get_raw_data_for_programs_chunking(self, mock_get_programs):
+        """Test that large UUID lists are chunked properly."""
+        # Create 25 UUIDs (more than default chunk size of 20)
+        uuids = [
+            UUID(f"{i:08d}-1111-1111-1111-111111111111")
+            for i in range(25)
+        ]
+
+        # Mock API to return empty list for simplicity
+        mock_get_programs.return_value = []
+        ProgramDetails._get_raw_data_for_programs(uuids, chunk_size=10)
+
+        # Should be called 3 times (25 UUIDs / 10 per chunk = 3 chunks)
+        self.assertEqual(mock_get_programs.call_count, 3)
+
+        # Verify chunk sizes
+        call_args_list = mock_get_programs.call_args_list
+        # First chunk: 10 UUIDs
+        self.assertEqual(len(call_args_list[0][0][0]), 10)
+        # Second chunk: 10 UUIDs
+        self.assertEqual(len(call_args_list[1][0][0]), 10)
+        # Third chunk: 5 UUIDs
+        self.assertEqual(len(call_args_list[2][0][0]), 5)
+
+    @patch.object(DiscoveryServiceClient, 'get_programs_by_uuids')
+    def test_get_raw_data_for_programs_missing_programs(
+        self, mock_get_programs
+    ):
+        """Test handling of programs not found in Discovery."""
+        # Mock API to return only one program (missing the second)
+        mock_get_programs.return_value = [self.program_1_data]
+
+        uuids = [self.program_uuid_1, self.program_uuid_2]
+        result = ProgramDetails._get_raw_data_for_programs(uuids)
+
+        # Should return found program and empty dict for missing
+        expected = {
+            str(self.program_uuid_1): self.program_1_data,
+            str(self.program_uuid_2): {},  # Missing program gets empty dict
+        }
+        self.assertEqual(result, expected)
+
+        # Found program should be cached
+        self.assertEqual(
+            cache.get(f'program:{self.program_uuid_1}'), self.program_1_data
+        )
+
+        # Missing program should NOT be cached (empty dict not cached)
+        self.assertIsNone(
+            cache.get(f'program:{self.program_uuid_2}')
+        )
+
+    @patch.object(DiscoveryServiceClient, 'get_programs_by_uuids')
+    def test_get_raw_data_for_programs_missing_programs_not_cached(
+        self, mock_get_programs
+    ):
+        """Test that missing programs are not cached and trigger API calls on subsequent requests."""
+        # Mock API to return empty list (no programs found)
+        mock_get_programs.return_value = []
+
+        uuid = self.program_uuid_1
+
+        # First call - should trigger API call
+        result1 = ProgramDetails._get_raw_data_for_programs([uuid])
+        self.assertEqual(result1, {str(uuid): {}})
+        self.assertEqual(mock_get_programs.call_count, 1)
+
+        # Missing program should NOT be cached
+        self.assertIsNone(cache.get(f'program:{uuid}'))
+
+        # Second call - should trigger another API call since missing programs aren't cached
+        result2 = ProgramDetails._get_raw_data_for_programs([uuid])
+        self.assertEqual(result2, {str(uuid): {}})
+        self.assertEqual(mock_get_programs.call_count, 2)  # Should be called again
+
+    def test_load_many_empty_list(self):
+        """Test that load_many with empty list returns empty dict."""
+        result = ProgramDetails.load_many([])
+        self.assertEqual(result, {})
+
+    @patch.object(ProgramDetails, '_get_raw_data_for_programs')
+    def test_load_many_creates_instances(self, mock_get_raw_data):
+        """Test that load_many creates ProgramDetails instances with
+        correct data."""
+        mock_get_raw_data.return_value = {
+            str(self.program_uuid_1): self.program_1_data,
+            str(self.program_uuid_2): self.program_2_data,
+        }
+
+        uuids = [self.program_uuid_1, self.program_uuid_2]
+        result = ProgramDetails.load_many(uuids)
+
+        # Should call bulk fetch method (chunk_size will be from environment)
+        self.assertEqual(mock_get_raw_data.call_count, 1)
+        call_args = mock_get_raw_data.call_args
+        self.assertEqual(call_args[0][0], [str(self.program_uuid_1), str(self.program_uuid_2)])
+        # chunk_size is the second argument, verify it's a positive integer
+        self.assertIsInstance(call_args[0][1], int)
+        self.assertGreater(call_args[0][1], 0)
+        # Should return correct number of instances
+        self.assertEqual(len(result), 2)
+        self.assertIn(self.program_uuid_1, result)
+        self.assertIn(self.program_uuid_2, result)
+
+        # Instances should have correct data
+        program_1 = result[self.program_uuid_1]
+        program_2 = result[self.program_uuid_2]
+
+        self.assertIsInstance(program_1, ProgramDetails)
+        self.assertIsInstance(program_2, ProgramDetails)
+        self.assertEqual(program_1.uuid, self.program_uuid_1)
+        self.assertEqual(program_2.uuid, self.program_uuid_2)
+        self.assertEqual(program_1.title, "Test Program 1")
+        self.assertEqual(program_2.title, "Test Program 2")
+
+    @patch.object(ProgramDetails, '_get_raw_data_for_programs')
+    def test_load_many_passes_chunk_size(self, mock_get_raw_data):
+        """Test that load_many passes chunk_size parameter to _get_raw_data_for_programs."""
+        mock_get_raw_data.return_value = {
+            str(self.program_uuid_1): self.program_1_data,
+        }
+
+        uuids = [self.program_uuid_1]
+        ProgramDetails.load_many(uuids, chunk_size=15)
+
+        # Should call bulk fetch method with explicit chunk_size
+        mock_get_raw_data.assert_called_once_with([
+            str(self.program_uuid_1)
+        ], 15)
+
+    @patch.object(ProgramDetails, '_get_raw_data_for_programs')
+    @override_settings(REGISTRAR_DISCOVERY_PROGRAMS_API_BATCH_SIZE=7)
+    def test_load_many_uses_env_batch_size(self, mock_get_raw_data):
+        """Test that load_many uses environment batch size when no chunk_size provided."""
+        mock_get_raw_data.return_value = {
+            str(self.program_uuid_1): self.program_1_data,
+        }
+
+        uuids = [self.program_uuid_1]
+        ProgramDetails.load_many(uuids)  # No chunk_size parameter
+
+        # Should call bulk fetch method with environment batch size
+        mock_get_raw_data.assert_called_once_with([
+            str(self.program_uuid_1)
+        ], 7)
+
+    def test_create_with_raw_data(self):
+        """Test that _create_with_raw_data creates instance correctly."""
+        # pylint: disable=protected-access
+        program = ProgramDetails._create_with_raw_data(
+            self.program_uuid_1, self.program_1_data
+        )
+        self.assertIsInstance(program, ProgramDetails)
+        self.assertEqual(program.uuid, self.program_uuid_1)
+        self.assertEqual(program.raw_data, self.program_1_data)
+        self.assertEqual(program.title, "Test Program 1")
+        self.assertEqual(program.program_type, "Masters")
+
+    def test_create_with_raw_data_empty(self):
+        """Test that _create_with_raw_data handles empty data."""
+        # pylint: disable=protected-access
+        program = ProgramDetails._create_with_raw_data(
+            self.program_uuid_1, {}
+        )
+
+        self.assertIsInstance(program, ProgramDetails)
+        self.assertEqual(program.uuid, self.program_uuid_1)
+        self.assertEqual(program.raw_data, {})
+        self.assertIsNone(program.title)
+        self.assertIsNone(program.program_type)
+
+    def test_clear_cache_for_programs(self):
+        """Test that clear_cache_for_programs removes correct cache entries."""
+        # Pre-populate cache
+        cache.set(
+            f'program:{self.program_uuid_1}', self.program_1_data, 300
+        )
+        cache.set(
+            f'program:{self.program_uuid_2}', self.program_2_data, 300
+        )
+        cache.set(
+            f'program:{self.program_uuid_3}', self.program_3_data, 300
+        )
+
+        # Clear cache for two programs
+        ProgramDetails.clear_cache_for_programs([
+            self.program_uuid_1, self.program_uuid_2
+        ])
+
+        # Those programs should be cleared
+        self.assertIsNone(
+            cache.get(f'program:{self.program_uuid_1}')
+        )
+        self.assertIsNone(
+            cache.get(f'program:{self.program_uuid_2}')
+        )
+
+        # Third program should remain
+        self.assertEqual(
+            cache.get(f'program:{self.program_uuid_3}'),
+            self.program_3_data
+        )
+
+    @patch('registrar.apps.core.discovery_cache.DiscoveryServiceClient.get_programs_by_uuids')
+    @override_settings(REGISTRAR_DISCOVERY_PROGRAMS_API_BATCH_SIZE=5)
+    def test_get_raw_data_for_programs_uses_env_batch_size(self, mock_get_programs):
+        """Test that _get_raw_data_for_programs uses environment batch size setting."""
+        # Setup mock to return different programs for different chunks
+        def side_effect(uuids):
+            return [{'uuid': uuid, 'title': f'Program {uuid}'} for uuid in uuids]
+        mock_get_programs.side_effect = side_effect
+
+        # Create 12 UUIDs to force chunking with batch size 5
+        uuids = [str(uuid4()) for _ in range(12)]
+
+        # Call with no explicit chunk_size to use environment setting
+        ProgramDetails._get_raw_data_for_programs(uuids)
+
+        # Should have made 3 calls (5, 5, 2) based on batch size 5
+        self.assertEqual(mock_get_programs.call_count, 3)
+
+        # Check the call arguments
+        calls = mock_get_programs.call_args_list
+        self.assertEqual(len(calls[0][0][0]), 5)  # First chunk: 5 UUIDs
+        self.assertEqual(len(calls[1][0][0]), 5)  # Second chunk: 5 UUIDs
+        self.assertEqual(len(calls[2][0][0]), 2)  # Third chunk: 2 UUIDs
+
+    @patch('registrar.apps.core.discovery_cache.DiscoveryServiceClient.get_programs_by_uuids')
+    def test_get_raw_data_for_programs_explicit_chunk_size_overrides_env(self, mock_get_programs):
+        """Test that explicit chunk_size parameter overrides environment setting."""
+        mock_get_programs.return_value = []
+
+        # Create 6 UUIDs
+        uuids = [str(uuid4()) for _ in range(6)]
+
+        # Call with explicit chunk_size=3
+        ProgramDetails._get_raw_data_for_programs(uuids, chunk_size=3)
+
+        # Should have made 2 calls (3, 3) based on explicit chunk size 3
+        self.assertEqual(mock_get_programs.call_count, 2)
+
+        # Check the call arguments
+        calls = mock_get_programs.call_args_list
+        self.assertEqual(len(calls[0][0][0]), 3)  # First chunk: 3 UUIDs
+        self.assertEqual(len(calls[1][0][0]), 3)  # Second chunk: 3 UUIDs

--- a/registrar/settings/base.py
+++ b/registrar/settings/base.py
@@ -345,3 +345,8 @@ SIMPLE_HISTORY_DATE_INDEX = False
 
 # Keep using deprecated pytz for Django>4
 USE_DEPRECATED_PYTZ = True
+
+# Discovery Programs Batch API Batch size
+# Use to get Programs in batches from Discovery
+# CAUTION: Setting to higher batch size may have risks exceeding URL limits
+REGISTRAR_DISCOVERY_PROGRAMS_API_BATCH_SIZE = 20


### PR DESCRIPTION
This pull request implements efficient bulk fetching and caching for program data by UUID, adds related tests, and introduces a configurable chunk size for batch API requests. The main goal is to reduce the number of API calls to the Discovery service when loading multiple programs, improving performance and scalability.

**Bulk fetching and caching improvements:**

* Added `get_programs_by_uuids` to `DiscoveryServiceClient` for fetching multiple programs by UUID in a single API call, with proper error handling and empty-list short-circuiting.
* Introduced `_get_raw_data_for_programs` and `_fetch_programs_bulk` in `ProgramDetails` to efficiently retrieve and cache program data in batches, minimizing redundant API calls.
* Refactored `ProgramDetails.load_many` to use the new bulk-fetching logic, returning a dictionary of `ProgramDetails` instances keyed by UUID, and added `_create_with_raw_data` for instantiating objects with pre-fetched data.

**Configurability and code quality:**

* Added `_get_default_chunk_size` to `ProgramDetails` for reading the batch size from settings, defaulting to 20 if not set.
* Improved code formatting and logging for readability and maintainability. [[1]](diffhunk://#diff-8bc4093ebbbfec810d716620bbdd21d1d67fb31832494e3ed621c9bf82c6e656L47-R48) [[2]](diffhunk://#diff-3223efced4f2b78cae089a05b37a4d2f67122f6823139bf558064d5f8b43f905L98-R100) [[3]](diffhunk://#diff-3223efced4f2b78cae089a05b37a4d2f67122f6823139bf558064d5f8b43f905L107-R110) [[4]](diffhunk://#diff-5a2a1ff65ea3cad9bd3a6d47b7ad13b96c2b3ccdacaf5af12db8c0607cc248e8L65-R70) [[5]](diffhunk://#diff-5a2a1ff65ea3cad9bd3a6d47b7ad13b96c2b3ccdacaf5af12db8c0607cc248e8L77-R113) [[6]](diffhunk://#diff-5a2a1ff65ea3cad9bd3a6d47b7ad13b96c2b3ccdacaf5af12db8c0607cc248e8L114-R134)

**Test coverage:**

* Added comprehensive tests for `get_programs_by_uuids`, including cases for empty lists and single UUIDs, ensuring robust behavior and correct API usage.
* Updated and reformatted existing tests for clarity and consistency, and imported missing utilities.

These changes collectively make program data access more efficient and robust, especially when working with large sets of UUIDs.

**JIRA:** https://2u-internal.atlassian.net/browse/COSMO2-700
