### PR TITLE
chore: Update CI workflows to use ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         python-version: ['3.12']
         toxenv: [django42]
     steps:

--- a/.github/workflows/mysql8-check-migrations.yml
+++ b/.github/workflows/mysql8-check-migrations.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04 ]
+        os: [ ubuntu-latest ]
         python-version: [ 3.12 ]
 
     steps:


### PR DESCRIPTION
This pull request updates the operating system used in GitHub Actions workflows to ensure compatibility with the latest environment and security updates.

CI/CD workflow updates:

* Updated the `os` matrix in `.github/workflows/ci.yml` from `ubuntu-20.04` to `ubuntu-latest` to use the most recent Ubuntu runner in GitHub Actions.
* Updated the `os` matrix in `.github/workflows/mysql8-check-migrations.yml` from `ubuntu-20.04` to `ubuntu-latest` for consistency and up-to-date testing environments.## Description


