### PR TITLE
feat: Upgrading storages with new dict Django52

### DIFF
--- a/registrar/settings/base.py
+++ b/registrar/settings/base.py
@@ -189,10 +189,18 @@ LOCALE_PATHS = (
     root('conf', 'locale'),
 )
 
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
+}
+
 # MEDIA CONFIGURATION
 MEDIA_ROOT = root('media')
 MEDIA_URL = '/api/media/'
-DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
 REGISTRAR_BUCKET = 'change-me-to-registrar-bucket'
 PROGRAM_REPORTS_BUCKET = 'change-me-to-program-reports-bucket'
 PROGRAM_REPORTS_FOLDER = 'reports_v2'
@@ -325,7 +333,6 @@ CSRF_COOKIE_SECURE = False
 EXTRA_APPS = []
 SERVICE_USER = 'registrar_service_user'
 SESSION_EXPIRE_AT_BROWSER_CLOSE = False
-STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
 CSRF_TRUSTED_ORIGINS = []
 CACHES = {
     'default': {

--- a/registrar/settings/devstack.py
+++ b/registrar/settings/devstack.py
@@ -35,7 +35,7 @@ DATABASES = {
     }
 }
 
-staticfiles_storage = os.environ.get('STATICFILES_STORAGE', 'django.contrib.staticfiles.storage.StaticFilesStorage')
+staticfiles_storage = os.environ.get('STATICFILES_STORAGE')
 
 if staticfiles_storage:
     STORAGES["staticfiles"]["BACKEND"] = staticfiles_storage

--- a/registrar/settings/devstack.py
+++ b/registrar/settings/devstack.py
@@ -35,7 +35,11 @@ DATABASES = {
     }
 }
 
-STATICFILES_STORAGE = os.environ.get('STATICFILES_STORAGE', 'django.contrib.staticfiles.storage.StaticFilesStorage')
+staticfiles_storage = os.environ.get('STATICFILES_STORAGE', 'django.contrib.staticfiles.storage.StaticFilesStorage')
+
+if staticfiles_storage:
+    STORAGES["staticfiles"]["BACKEND"] = staticfiles_storage
+
 STATIC_URL = os.environ.get('STATIC_URL', '/static/')
 
 LMS_BASE_URL = 'http://edx.devstack.lms:18000'

--- a/registrar/settings/production.py
+++ b/registrar/settings/production.py
@@ -36,12 +36,12 @@ with open(CONFIG_FILE, encoding='utf-8') as f:
     default_file_storage = MEDIA_STORAGE_BACKEND.pop('DEFAULT_FILE_STORAGE', None)
     staticfiles_storage = MEDIA_STORAGE_BACKEND.pop('STATICFILES_STORAGE', None)
 
-    vars().update(MEDIA_STORAGE_BACKEND)
-
     if default_file_storage:
         STORAGES["default"]["BACKEND"] = default_file_storage
     if staticfiles_storage:
         STORAGES["staticfiles"]["BACKEND"] = staticfiles_storage
+
+    vars().update(MEDIA_STORAGE_BACKEND)
 
 DB_OVERRIDES = dict(
     PASSWORD=environ.get('DB_MIGRATION_PASS', DATABASES['default']['PASSWORD']),

--- a/registrar/settings/production.py
+++ b/registrar/settings/production.py
@@ -32,7 +32,16 @@ with open(CONFIG_FILE, encoding='utf-8') as f:
             vars()[key].update(value)
 
     vars().update(config_from_yaml)
+
+    default_file_storage = MEDIA_STORAGE_BACKEND.pop('DEFAULT_FILE_STORAGE', None)
+    staticfiles_storage = MEDIA_STORAGE_BACKEND.pop('STATICFILES_STORAGE', None)
+
     vars().update(MEDIA_STORAGE_BACKEND)
+
+    if default_file_storage:
+        STORAGES["default"]["BACKEND"] = default_file_storage
+    if staticfiles_storage:
+        STORAGES["staticfiles"]["BACKEND"] = staticfiles_storage
 
 DB_OVERRIDES = dict(
     PASSWORD=environ.get('DB_MIGRATION_PASS', DATABASES['default']['PASSWORD']),

--- a/registrar/settings/test.py
+++ b/registrar/settings/test.py
@@ -45,7 +45,7 @@ CELERY_BROKER_URL = 'memory://localhost/'
 # END CELERY
 
 # Media
-DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+STORAGES["default"]["BACKEND"] = 'storages.backends.s3boto3.S3Boto3Storage'
 AWS_LOCATION = ''
 AWS_QUERYSTRING_AUTH = True
 AWS_QUERYSTRING_EXPIRE = 3600


### PR DESCRIPTION
Deprecate STATICFILES_STORAGE and DEFAULT_FILE_STORAGE, and use STORAGE to upgrade to Django 5.2